### PR TITLE
feat: support method eth_getBlockReceipts

### DIFF
--- a/src/rpc_cache_handler/eth_get_block_receipts.rs
+++ b/src/rpc_cache_handler/eth_get_block_receipts.rs
@@ -1,0 +1,26 @@
+use anyhow::Context;
+use serde_json::Value;
+
+use crate::rpc_cache_handler::RpcCacheHandler;
+
+#[derive(Default, Clone)]
+pub struct EthGetBlockReceipts;
+
+impl RpcCacheHandler for EthGetBlockReceipts {
+    fn method_name(&self) -> &'static str {
+        "eth_getBlockReceipts"
+    }
+
+    fn extract_cache_key(&self, params: &Value) -> anyhow::Result<Option<String>> {
+        let params = params
+            .as_array()
+            .context("params not found or not an array")?;
+
+        let block_number = params[0].as_str().context("params[0] not a string")?;
+        let block_number =
+            u64::from_str_radix(&block_number[2..], 16).context("block number not a hex string")?;
+
+            Ok(Some(format!("0x{:x}", block_number)))
+    }
+}
+

--- a/src/rpc_cache_handler/mod.rs
+++ b/src/rpc_cache_handler/mod.rs
@@ -12,6 +12,7 @@ pub use eth_get_transaction_by_block_number_and_index::EthGetTransactionByBlockN
 pub use eth_get_transaction_by_hash::EthGetTransactionByHash;
 pub use eth_get_transaction_count::EthGetTransactionCount;
 pub use eth_get_transaction_receipt::EthGetTransactionReceipt;
+pub use eth_get_block_receipts::EthGetBlockReceipts;
 
 mod common;
 mod eth_call;
@@ -25,6 +26,7 @@ mod eth_get_transaction_by_block_number_and_index;
 mod eth_get_transaction_by_hash;
 mod eth_get_transaction_count;
 mod eth_get_transaction_receipt;
+mod eth_get_block_receipts;
 
 pub trait RpcCacheHandler: Send + Sync {
     fn method_name(&self) -> &'static str;
@@ -50,6 +52,7 @@ pub fn all_factories() -> Vec<RpcCacheHandlerFactory> {
         || Box::new(EthGetTransactionByBlockNumberAndIndex) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetTransactionByHash) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetTransactionCount) as Box<dyn RpcCacheHandler>,
+        || Box::new(EthGetBlockReceipts) as Box<dyn RpcCacheHandler>,
         || Box::<EthGetTransactionReceipt>::default() as Box<dyn RpcCacheHandler>,
     ]
 }


### PR DESCRIPTION
feat: support method eth_getBlockReceipts


test: 
```shell
curl -X POST  'http://127.0.0.1:8124/eth-chain' -d '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["0x12329f0"],"id":1}' -H 'Content-Type: application/json'
```

backend logs:

```shell
[2024-01-25T06:11:58Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 0x12329f0
[2024-01-25T06:11:59Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 0x12329f0
[2024-01-25T06:11:59Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 0x12329f0
[2024-01-25T06:12:06Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 0x12329f0
[2024-01-25T06:12:07Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 0x12329f0
```